### PR TITLE
Run demos in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+__pycache__
+.gitignore
+convert
+data
+docker-compose.*.yml
+Dockerfile
+github
+LICENSE
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+static/results

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM nvidia/cuda:11.1.1-runtime-ubuntu20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY requirements.txt /requirements.txt
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    libgl1-mesa-glx \
+    libglib2.0-0 \
+    python-is-python3 \
+    python3 \
+    python3-pip \
+  && python -m pip install --no-cache-dir -r requirements.txt \
+  && rm -f requirements.txt \
+  && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -45,8 +45,33 @@ you can upload a image the click submit, see what happen.<br/>
 http://0.0.0.0:5000/
 
 
+### Run in docker
 
 
+Follow the instructions from <https://docs.docker.com/engine/install/ubuntu>,
+  <https://github.com/NVIDIA/nvidia-container-runtime#docker-engine-setup> and
+  <https://docs.docker.com/compose/install/#install-compose-on-linux-systems> to setup your environment.
+
+- Build the image
+
+```
+docker-compose build
+
+```
+
+- Run the demo
+
+```
+docker-compose up
+
+```
+
+- Run the flask demo
+
+```
+docker-compose -f docker-compose.yml -f docker-compose.flask.yml up
+
+```
 
 ## Citation
 If you find *M-LSD* useful in your project, please consider to cite the following paper.

--- a/demo.py
+++ b/demo.py
@@ -27,8 +27,7 @@ def main():
 
     img = cv2.imread(img_fn)
     img = cv2.resize(img, (512, 512))
-    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
-    lines = pred_lines(img, model, [512, 512], 0.1, 20)
+    lines = pred_lines(cv2.cvtColor(img, cv2.COLOR_BGR2RGB), model, [512, 512], 0.1, 20)
 
     for l in lines:
         cv2.line(img, (int(l[0]), int(l[1])), (int(l[2]), int(l[3])), (200,200,0), 1,16)

--- a/demo.py
+++ b/demo.py
@@ -2,7 +2,6 @@ import torch
 import os
 import sys
 import cv2
-sys.path.append(os.path.dirname(__file__))
 
 from models.mbv2_mlsd_tiny import  MobileV2_MLSD_Tiny
 from models.mbv2_mlsd_large import  MobileV2_MLSD_Large
@@ -13,6 +12,8 @@ from utils import  pred_lines
 
 def main():
     current_dir = os.path.dirname(__file__)
+    if current_dir == "":
+        current_dir = "./"
     # model_path = current_dir+'/models/mlsd_tiny_512_fp32.pth'
     # model = MobileV2_MLSD_Tiny().cuda().eval()
 

--- a/demo_MLSD_flask.py
+++ b/demo_MLSD_flask.py
@@ -32,6 +32,8 @@ os.environ['CUDA_VISIBLE_DEVICES'] = '0' # CPU mode
 
 # flask
 current_dir = os.path.dirname(__file__)
+if current_dir == "":
+    current_dir = "./"
 app = Flask(__name__, template_folder=current_dir+ '/templates/')
 logger = app.logger
 logger.info('init demo app')

--- a/docker-compose.flask.yml
+++ b/docker-compose.flask.yml
@@ -1,0 +1,7 @@
+version: "2"
+
+services:
+  app:
+    command: "python demo_MLSD_flask.py"
+    ports:
+      - "5000:5000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "2"
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: mlsd
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=0
+      - NVIDIA_DRIVER_CAPABILITIES=compute
+    volumes:
+      - ${PWD}:/ws
+    working_dir: /ws
+    command: "python demo.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ opencv-python
 pillow
 torch
 Flask
+requests


### PR DESCRIPTION
This PR allows to run the provided demos in a docker environment based on `ubuntu 20.04` and `cuda 11.1.1`. As the code is directly mounted in the container, modifications can be made without having to rebuild the image.